### PR TITLE
feat: implement global audio singleton for persistent playback across route changes

### DIFF
--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { getGlobalAudio } from "./audioSingleton";
 
 // Default fallback playlist; real files are discovered from /api/audio
 const DEFAULT_PLAYLIST = [
@@ -96,10 +97,9 @@ export default function MusicPlayer({ playlist }: { playlist?: Track[] }) {
     lenRef.current = Math.max(1, effectiveTracks.length);
   }, [effectiveTracks.length]);
 
-  // Create and wire audio element
+  // Create and wire audio element (global singleton to survive route changes/HMR)
   useEffect(() => {
-    const a = new Audio();
-  a.preload = "auto";
+    const a = getGlobalAudio();
     audioRef.current = a;
 
     const onPlay = () => {
@@ -128,7 +128,7 @@ export default function MusicPlayer({ playlist }: { playlist?: Track[] }) {
     a.addEventListener("error", onError);
 
     return () => {
-      a.pause();
+      // Do not pause on unmount; keep music playing across page remounts.
       a.removeEventListener("play", onPlay);
       a.removeEventListener("pause", onPause);
       a.removeEventListener("ended", onEnded);

--- a/app/components/ui/audioSingleton.ts
+++ b/app/components/ui/audioSingleton.ts
@@ -1,0 +1,21 @@
+declare global {
+  interface Window {
+    __ALG_HUB_AUDIO?: HTMLAudioElement;
+  }
+}
+
+export function getGlobalAudio(): HTMLAudioElement {
+  if (typeof window === "undefined") {
+    // SSR safety: return a dummy Audio-like object; won't be used client-side
+    // but keeps types happy when imported in a server context accidentally.
+    return new (class extends Audio {
+      // no-op placeholder
+    })();
+  }
+  if (!window.__ALG_HUB_AUDIO) {
+    const a = new Audio();
+    a.preload = "auto";
+    window.__ALG_HUB_AUDIO = a;
+  }
+  return window.__ALG_HUB_AUDIO!;
+}


### PR DESCRIPTION
This pull request refactors the `MusicPlayer` component to use a global singleton audio element, ensuring that music playback persists across route changes and hot module reloads (HMR). It introduces a new utility for managing the audio instance and updates the component logic to leverage this singleton, improving user experience by preventing music interruption.

**Music playback persistence and audio management:**

* Added `getGlobalAudio` utility in `audioSingleton.ts` to create and manage a global singleton `Audio` element, ensuring only one audio instance exists and persists across page navigation and reloads.
* Updated `MusicPlayer.tsx` to use the global audio singleton instead of creating a new `Audio` element on each mount, allowing music to continue playing even when the component unmounts/remounts. [[1]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851R3) [[2]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851L99-R102)
* Changed cleanup logic in `MusicPlayer.tsx` to avoid pausing the audio on component unmount, further supporting uninterrupted playback.