### PR TITLE
feat: update playForIndex to conditionally trigger camera capture based on navigation

### DIFF
--- a/app/components/sections/GameScroller.tsx
+++ b/app/components/sections/GameScroller.tsx
@@ -96,11 +96,14 @@ export default function GameScroller() {
     }
   };
 
-  const playForIndex = (idx: number) => {
+  const playForIndex = (idx: number, opts?: { fromNav?: boolean }) => {
+    const fromNav = opts?.fromNav === true;
     const g = items[idx];
     if (!g) return;
     // For the first game, trigger the camera capture flow instead of immediate audio
     if (g.id === "sorting-sprint") {
+      // When navigating with Prev/Next, don't open the camera automatically.
+      if (fromNav) return;
       setShowCam(true);
       return;
     }
@@ -118,14 +121,14 @@ export default function GameScroller() {
     setActive((i) => {
       const nxt = Math.max(0, Math.min(items.length - 1, i + dir));
       // Only play on user-initiated navigation
-      playForIndex(nxt);
+      playForIndex(nxt, { fromNav: true });
       return nxt;
     });
   };
   const goTo = (idx: number) => {
     const nxt = Math.max(0, Math.min(items.length - 1, idx));
     setActive(nxt);
-    playForIndex(nxt);
+    playForIndex(nxt, { fromNav: true });
   };
 
   return (


### PR DESCRIPTION
This pull request updates the navigation behavior in the `GameScroller` component to improve user experience when switching between games. The main change ensures that the camera capture flow for the "sorting-sprint" game is only triggered on direct selection, not when navigating with the Prev/Next buttons.

Navigation behavior improvements:

* Modified the `playForIndex` function to accept an optional `opts` parameter, allowing differentiation between navigation-triggered and direct selection-triggered actions. (`app/components/sections/GameScroller.tsx`)
* Updated navigation handlers (`setActive` and `goTo`) to pass `{ fromNav: true }` to `playForIndex`, preventing automatic camera activation when navigating with Prev/Next. (`app/components/sections/GameScroller.tsx`)