### PR TITLE
feat(admin): add achievement gain statistics and UI components to the admin dashboard

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -11,6 +11,10 @@ import { useRef } from '@/hooks/useRef';
 import { signOutUser } from '@/actions/auth/sign-out';
 import type {
   AdminNavTarget,
+  AchievementGainCardProps,
+  AchievementGainChartProps,
+  AchievementGainPoint,
+  AchievementGainResponse,
   StudentGrowthCardProps,
   StudentGrowthChartProps,
   StudentGrowthPoint,
@@ -117,6 +121,9 @@ function AdminDashboardContent({ irisRef }: { irisRef: MutableRefObject<IrisHand
   const [studentGrowth, setStudentGrowth] = useState<StudentGrowthPoint[] | null>(null);
   const [studentGrowthLoading, setStudentGrowthLoading] = useState(true);
   const [studentGrowthError, setStudentGrowthError] = useState<string | null>(null);
+  const [achievementGain, setAchievementGain] = useState<AchievementGainPoint[] | null>(null);
+  const [achievementGainLoading, setAchievementGainLoading] = useState(true);
+  const [achievementGainError, setAchievementGainError] = useState<string | null>(null);
   const [signOutPending, setSignOutPending] = useState(false);
   const [signOutError, setSignOutError] = useState<string | null>(null);
 
@@ -162,6 +169,52 @@ function AdminDashboardContent({ irisRef }: { irisRef: MutableRefObject<IrisHand
     }
 
     loadGrowth();
+
+    return () => {
+      isActive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const loadAchievementStats = async () => {
+      setAchievementGainLoading(true);
+      setAchievementGainError(null);
+      try {
+        const response = await fetch('/api/admin/achievements-gained', { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const payload = (await response.json()) as AchievementGainResponse;
+        if (payload.error) {
+          throw new Error(payload.error);
+        }
+
+        const points = Array.isArray(payload.data) ? payload.data : [];
+        if (!isActive) {
+          return;
+        }
+
+        setAchievementGain(points);
+      } catch (error) {
+        if (!isActive) {
+          return;
+        }
+        console.error('[AdminDashboard] Failed to fetch achievement gains', error);
+        setAchievementGain(null);
+        setAchievementGainError('Unable to load achievement stats right now.');
+      } finally {
+        if (isActive) {
+          setAchievementGainLoading(false);
+        }
+      }
+    };
+
+    loadAchievementStats().catch((error) => {
+      console.error('[AdminDashboard] Unexpected achievement stats failure', error);
+    });
 
     return () => {
       isActive = false;
@@ -369,6 +422,8 @@ function AdminDashboardContent({ irisRef }: { irisRef: MutableRefObject<IrisHand
             </section>
 
             <StudentGrowthCard data={studentGrowth} loading={studentGrowthLoading} error={studentGrowthError} />
+
+            <AchievementsGainedCard data={achievementGain} loading={achievementGainLoading} error={achievementGainError} />
 
             <section className="grid gap-5 lg:grid-cols-3">
               {PLACEHOLDER_PANELS.map((panel) => (
@@ -605,6 +660,197 @@ function StudentGrowthChart({ data, formatter, comparisonLabel }: StudentGrowthC
           fontWeight="600"
         >
           Total Students ({comparisonLabel})
+        </text>
+      </svg>
+    </div>
+  );
+}
+
+function AchievementsGainedCard({ data, loading, error }: AchievementGainCardProps): ReactElement {
+  const numberFormatter = useMemo(() => new Intl.NumberFormat('en-US'), []);
+  const hasData = Boolean(data && data.length > 0);
+  const latestPoint = hasData && data ? data[data.length - 1] : null;
+  const previousPoint = hasData && data && data.length > 1 ? data[data.length - 2] : null;
+  const todayUnlocks = latestPoint ? latestPoint.unlocked : 0;
+  const comparisonLabel = previousPoint ? `vs. ${previousPoint.date}` : 'First recorded unlocks';
+
+  const todayLabel = loading || !hasData
+    ? 'Awaiting data'
+    : todayUnlocks === 0
+      ? 'No unlocks today'
+      : `${todayUnlocks} today`;
+
+  return (
+    <article className="rounded-3xl border border-fuchsia-300/35 bg-fuchsia-500/10 p-6 text-fuchsia-50 shadow-[0_20px_42px_rgba(134,25,143,0.28)] backdrop-blur">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Achievements Gained</h2>
+          <p className="mt-1 text-sm text-fuchsia-100/80">
+            Daily achievement unlocks across AlgoHub learners.
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white/10 px-4 py-2 text-right text-xs uppercase tracking-[0.18em] text-white/80 shadow-inner ring-1 ring-white/15">
+          <div className="text-[10px] font-semibold text-fuchsia-200/85">Total Unlocks</div>
+          <div className="mt-1 text-base font-bold text-white">
+            {latestPoint ? numberFormatter.format(latestPoint.totalUnlocked) : loading ? '…' : '0'}
+          </div>
+          <div className="mt-1 text-[10px] font-medium text-fuchsia-200/75">{todayLabel}</div>
+        </div>
+      </div>
+
+      <div className="mt-6 min-h-[16rem] w-full">
+        {loading ? (
+          <div className="flex h-64 w-full items-center justify-center rounded-2xl border border-dashed border-white/20 bg-fuchsia-900/20 text-sm text-fuchsia-100/80">
+            Loading achievement stats…
+          </div>
+        ) : error ? (
+          <div className="flex h-64 w-full items-center justify-center rounded-2xl border border-rose-500/30 bg-rose-500/10 text-sm font-medium text-rose-100">
+            {error}
+          </div>
+        ) : hasData && data ? (
+          <AchievementsGainedChart data={data} formatter={numberFormatter} comparisonLabel={comparisonLabel} />
+        ) : (
+          <div className="flex h-64 w-full items-center justify-center rounded-2xl border border-white/20 bg-fuchsia-900/20 text-sm text-fuchsia-100/80">
+            No achievements unlocked yet.
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function AchievementsGainedChart({ data, formatter, comparisonLabel }: AchievementGainChartProps): ReactElement {
+  const chart = useMemo(() => {
+    if (!data.length) {
+      return null;
+    }
+
+    const width = 720;
+    const height = 260;
+    const padding = { top: 32, right: 36, bottom: 56, left: 72 };
+    const chartWidth = width - padding.left - padding.right;
+    const chartHeight = height - padding.top - padding.bottom;
+
+    const dateValues = data.map((point) => new Date(`${point.date}T00:00:00.000Z`).getTime());
+    const minDateValue = Math.min(...dateValues);
+    const maxDateValue = Math.max(...dateValues);
+    const dateRange = Math.max(1, maxDateValue - minDateValue);
+
+    const totals = data.map((point) => point.totalUnlocked);
+    const maxTotal = Math.max(...totals, 0);
+    const valueRange = Math.max(1, maxTotal);
+
+    const scaledPoints = data.map((point, index) => {
+      const dateValue = dateValues[index];
+      const x = padding.left + ((dateValue - minDateValue) / dateRange) * chartWidth;
+      const valueRatio = valueRange > 0 ? point.totalUnlocked / valueRange : 0;
+      const y = padding.top + (1 - valueRatio) * chartHeight;
+      return { ...point, x, y };
+    });
+
+    const pathD = scaledPoints
+      .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(2)} ${point.y.toFixed(2)}`)
+      .join(' ');
+
+    const baseY = padding.top + chartHeight;
+    const areaD = `${pathD} L${scaledPoints[scaledPoints.length - 1].x.toFixed(2)} ${baseY.toFixed(2)} L${scaledPoints[0].x.toFixed(2)} ${baseY.toFixed(2)} Z`;
+
+    const targetTickCount = Math.min(6, scaledPoints.length);
+    const tickInterval = targetTickCount > 1 ? Math.round((scaledPoints.length - 1) / (targetTickCount - 1)) : 1;
+    const xTicks = scaledPoints.reduce<{ x: number; label: string; date: string }[]>((acc, point, index) => {
+      if (index % tickInterval === 0 || index === scaledPoints.length - 1) {
+        acc.push({ x: point.x, label: point.date, date: point.date });
+      }
+      return acc;
+    }, []);
+
+    const yTickCount = 4;
+    const yTicks = Array.from({ length: yTickCount + 1 }).map((_, idx) => {
+      const ratio = idx / yTickCount;
+      const value = Math.round(maxTotal * ratio);
+      const y = padding.top + (1 - ratio) * chartHeight;
+      return { y, value };
+    });
+
+    const dateFormatter = new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: data.length > 40 ? undefined : 'numeric',
+      year: data.length > 120 ? 'numeric' : undefined,
+    });
+
+    return {
+      width,
+      height,
+      padding,
+      pathD,
+      areaD,
+      scaledPoints,
+      xTicks: xTicks.map((tick) => ({ x: tick.x, label: dateFormatter.format(new Date(`${tick.date}T00:00:00.000Z`)) })),
+      yTicks,
+      maxTotal,
+    };
+  }, [data]);
+
+  if (!chart) {
+    return (
+      <div className="flex h-64 w-full items-center justify-center rounded-2xl border border-white/20 bg-fuchsia-900/20 text-sm text-fuchsia-100/80">
+        No data available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative h-64 w-full">
+      <svg
+        role="img"
+        aria-label="Line chart showing achievements gained over time"
+        viewBox={`0 0 ${chart.width} ${chart.height}`}
+        className="h-full w-full"
+      >
+        <defs>
+          <linearGradient id="achievements-gain-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="rgba(217,70,239,0.6)" />
+            <stop offset="95%" stopColor="rgba(217,70,239,0)" />
+          </linearGradient>
+        </defs>
+
+        <g stroke="rgba(255,255,255,0.08)" strokeDasharray="4 6">
+          {chart.xTicks.map((tick) => (
+            <line key={`gain-grid-x-${tick.label}`} x1={tick.x} y1={chart.padding.top} x2={tick.x} y2={chart.height - chart.padding.bottom} />
+          ))}
+          {chart.yTicks.map((tick, index) => (
+            <line key={`gain-grid-y-${index}`} x1={chart.padding.left} y1={tick.y} x2={chart.width - chart.padding.right} y2={tick.y} />
+          ))}
+        </g>
+
+        <path d={chart.areaD} fill="url(#achievements-gain-gradient)" opacity="0.6" />
+        <path d={chart.pathD} fill="none" stroke="rgba(217,70,239,0.95)" strokeWidth="3" strokeLinejoin="round" strokeLinecap="round" />
+
+        {chart.scaledPoints.map((point) => (
+          <circle key={`gain-marker-${point.date}`} cx={point.x} cy={point.y} r={4.5} fill="rgba(217,70,239,1)" />
+        ))}
+
+        <g fontSize="12" fill="rgba(250,245,255,0.8)" fontWeight="500">
+          {chart.xTicks.map((tick) => (
+            <text key={`gain-label-x-${tick.label}`} x={tick.x} y={chart.height - chart.padding.bottom + 28} textAnchor="middle">
+              {tick.label}
+            </text>
+          ))}
+          {chart.yTicks.map((tick, index) => (
+            <text key={`gain-label-y-${index}`} x={chart.padding.left - 12} y={tick.y + 4} textAnchor="end">
+              {formatter.format(tick.value)}
+            </text>
+          ))}
+        </g>
+
+        <text
+          x={chart.padding.left}
+          y={chart.padding.top - 12}
+          fill="rgba(250,245,255,0.9)"
+          fontSize="12"
+          fontWeight="600"
+        >
+          Unlocks ({comparisonLabel})
         </text>
       </svg>
     </div>

--- a/app/api/admin/achievements-gained/route.ts
+++ b/app/api/admin/achievements-gained/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from 'next/server';
+import { getServiceSupabase } from '@/lib/supabase/serviceClient';
+
+type AchievementRow = {
+  unlocked_at: string | null;
+};
+
+type AchievementGainPoint = {
+  date: string;
+  unlocked: number;
+  totalUnlocked: number;
+};
+
+const MS_PER_DAY = 86_400_000;
+const MAX_DAY_WINDOW = 365;
+
+function toDateKey(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function parseUtcDateOnly(dateString: string): Date | null {
+  const date = new Date(`${dateString}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export async function GET() {
+  try {
+    const supabase = getServiceSupabase();
+    const { data, error } = await supabase
+      .from('user_achievements')
+      .select('unlocked_at')
+      .order('unlocked_at', { ascending: true });
+
+    if (error) {
+      console.error('[AchievementsGainedRoute] Failed to query user achievements', error);
+      return NextResponse.json({ error: error.message ?? 'Unable to load achievement stats' }, { status: 400 });
+    }
+
+    const rows = (data ?? []).filter((row): row is AchievementRow & { unlocked_at: string } => {
+      return typeof row.unlocked_at === 'string' && row.unlocked_at.length > 0;
+    });
+
+    if (rows.length === 0) {
+      return NextResponse.json(
+        { data: [], meta: { totalUnlocked: 0 }, generatedAt: new Date().toISOString() },
+        { headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const dayCounts = new Map<string, number>();
+    for (const row of rows) {
+      const createdAt = new Date(row.unlocked_at);
+      if (Number.isNaN(createdAt.getTime())) {
+        continue;
+      }
+      const dayKey = toDateKey(createdAt);
+      dayCounts.set(dayKey, (dayCounts.get(dayKey) ?? 0) + 1);
+    }
+
+    const sortedDays = Array.from(dayCounts.keys()).sort();
+    if (sortedDays.length === 0) {
+      return NextResponse.json(
+        { data: [], meta: { totalUnlocked: 0 }, generatedAt: new Date().toISOString() },
+        { headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const firstDay = parseUtcDateOnly(sortedDays[0]);
+    const lastDataDay = parseUtcDateOnly(sortedDays[sortedDays.length - 1]);
+
+    if (!firstDay || !lastDataDay) {
+      return NextResponse.json(
+        { data: [], meta: { totalUnlocked: 0 }, generatedAt: new Date().toISOString() },
+        { headers: { 'Cache-Control': 'no-store' } },
+      );
+    }
+
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const endDate = lastDataDay > today ? lastDataDay : today;
+
+    const maxWindowStart = new Date(endDate.getTime() - (MAX_DAY_WINDOW - 1) * MS_PER_DAY);
+    const startDate = firstDay < maxWindowStart ? maxWindowStart : firstDay;
+
+    let baseTotal = 0;
+    if (startDate > firstDay) {
+      for (const dayKey of sortedDays) {
+        const dayDate = parseUtcDateOnly(dayKey);
+        if (!dayDate || dayDate >= startDate) {
+          break;
+        }
+        baseTotal += dayCounts.get(dayKey) ?? 0;
+      }
+    }
+
+    const timeline: AchievementGainPoint[] = [];
+    let runningTotal = baseTotal;
+    const cursor = new Date(startDate);
+
+    while (cursor <= endDate) {
+      const dayKey = toDateKey(cursor);
+      const unlocked = dayCounts.get(dayKey) ?? 0;
+      runningTotal += unlocked;
+      timeline.push({ date: dayKey, unlocked, totalUnlocked: runningTotal });
+      cursor.setUTCDate(cursor.getUTCDate() + 1);
+    }
+
+    return NextResponse.json(
+      {
+        data: timeline,
+        meta: {
+          totalUnlocked: runningTotal,
+          windowStart: timeline.length > 0 ? timeline[0].date : toDateKey(startDate),
+          windowEnd: timeline.length > 0 ? timeline[timeline.length - 1].date : toDateKey(endDate),
+        },
+        generatedAt: new Date().toISOString(),
+      },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    console.error('[AchievementsGainedRoute] Unexpected failure', error);
+    return NextResponse.json({ error: 'Unable to load achievement stats' }, { status: 500 });
+  }
+}

--- a/app/components/ui/IrisTransition.tsx
+++ b/app/components/ui/IrisTransition.tsx
@@ -1,9 +1,12 @@
 "use client";
 import { forwardRef } from "react";
+import { createPortal } from "react-dom";
 import { useEffect } from "@/hooks/useEffect";
 import { useImperativeHandle } from "@/hooks/useImperativeHandle";
 import { useRef } from "@/hooks/useRef";
 import { useState } from "@/hooks/useState";
+
+let irisMaskIdCounter = 0;
 
 export type IrisHandle = {
   start: (opts?: { x?: number; y?: number; durationMs?: number; onDone?: () => void; mode?: "close" | "open" }) => void;
@@ -29,6 +32,11 @@ export default forwardRef<IrisHandle, { zIndex?: number }>(function IrisTransiti
   const [vw, setVw] = useState(0);
   const [vh, setVh] = useState(0);
   const [opacity, setOpacity] = useState(1);
+  const [portalEl, setPortalEl] = useState<HTMLElement | null>(null);
+  const [maskId] = useState(() => {
+    irisMaskIdCounter += 1;
+    return `iris-mask-${irisMaskIdCounter}`;
+  });
   const rafRef = useRef<number | null>(null);
   const runningRef = useRef(false);
   const fadeMs = 160;
@@ -37,27 +45,27 @@ export default forwardRef<IrisHandle, { zIndex?: number }>(function IrisTransiti
     start: ({ x, y, durationMs = 600, onDone, mode = "close" } = {}) => {
       if (runningRef.current) return;
       const reduce = prefersReducedMotion();
-  const vwNow = window.innerWidth;
-  const vhNow = window.innerHeight;
-  setVw(vwNow);
-  setVh(vhNow);
-  const cxVal = typeof x === "number" ? x : vwNow / 2;
-  const cyVal = typeof y === "number" ? y : vhNow / 2;
+      const vwNow = window.innerWidth;
+      const vhNow = window.innerHeight;
+      setVw(vwNow);
+      setVh(vhNow);
+      const cxVal = typeof x === "number" ? x : vwNow / 2;
+      const cyVal = typeof y === "number" ? y : vhNow / 2;
 
       // If user prefers reduced motion, keep the animation but shorter (no hard skip)
       const effectiveDuration = reduce ? Math.min(300, Math.max(180, durationMs)) : durationMs;
 
       // Compute a radius big enough to cover the farthest corner
-  const dx = Math.max(cxVal, vwNow - cxVal);
-  const dy = Math.max(cyVal, vhNow - cyVal);
+      const dx = Math.max(cxVal, vwNow - cxVal);
+      const dy = Math.max(cyVal, vhNow - cyVal);
       const startR = Math.hypot(dx, dy) + 20; // pad a bit
 
-  setCx(cxVal);
-  setCy(cyVal);
-  // Initialize radius based on mode: open starts from 0, close starts from full
-  setR(mode === "open" ? 0 : startR);
-  setVisible(true);
-  setOpacity(1);
+      setCx(cxVal);
+      setCy(cyVal);
+      // Initialize radius based on mode: open starts from 0, close starts from full
+      setR(mode === "open" ? 0 : startR);
+      setVisible(true);
+      setOpacity(1);
 
       runningRef.current = true;
       const t0 = performance.now();
@@ -96,6 +104,19 @@ export default forwardRef<IrisHandle, { zIndex?: number }>(function IrisTransiti
     if (rafRef.current) cancelAnimationFrame(rafRef.current);
   }, []);
 
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const host = document.createElement("div");
+    host.dataset.irisTransition = "";
+    document.body.appendChild(host);
+    setPortalEl(host);
+    return () => {
+      if (host.parentNode) {
+        host.parentNode.removeChild(host);
+      }
+    };
+  }, []);
+
   // Track viewport size for correct SVG dimensions
   useEffect(() => {
     const update = () => {
@@ -107,20 +128,28 @@ export default forwardRef<IrisHandle, { zIndex?: number }>(function IrisTransiti
     return () => window.removeEventListener("resize", update);
   }, []);
 
-  if (!visible) return null;
+  if (!portalEl) {
+    return null;
+  }
+
+  if (!visible) {
+    return null;
+  }
 
   // SVG mask: black rect with a circular transparent hole at (cx, cy) with radius rRef.current
-  return (
+  const overlay = (
     <div className="fixed inset-0 pointer-events-none" style={{ zIndex, opacity, transition: `opacity ${fadeMs}ms ease-out` }} aria-hidden>
-      <svg width="100%" height="100%" viewBox={`0 0 ${vw} ${vh}`} preserveAspectRatio="none" style={{ display: "block" }}>
+      <svg width="100%" height="100%" viewBox={`0 0 ${vw} ${vh}`} preserveAspectRatio="xMidYMid slice" style={{ display: "block" }}>
         <defs>
-          <mask id="iris-mask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" x="0" y="0" width={vw} height={vh}>
+          <mask id={maskId} maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" x="0" y="0" width={vw} height={vh}>
             <rect x="0" y="0" width={vw} height={vh} fill="white" />
             <circle cx={cx} cy={cy} r={r} fill="black" />
           </mask>
         </defs>
-        <rect x="0" y="0" width={vw} height={vh} fill="black" mask="url(#iris-mask)" />
+        <rect x="0" y="0" width={vw} height={vh} fill="black" mask={`url(#${maskId})`} />
       </svg>
     </div>
   );
+
+  return createPortal(overlay, portalEl);
 });

--- a/app/components/ui/MusicPlayer.tsx
+++ b/app/components/ui/MusicPlayer.tsx
@@ -1,5 +1,6 @@
 "use client";
 import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useEffect } from "@/hooks/useEffect";
 import { useMemo } from "@/hooks/useMemo";
 import { useRef } from "@/hooks/useRef";
@@ -37,10 +38,28 @@ export default function MusicPlayer({ playlist }: { playlist?: Track[] }) {
   const [volume, setVolume] = useState<number>(0.7);
   const [loop, setLoop] = useState<boolean>(false);
   const [prefsLoaded, setPrefsLoaded] = useState(false);
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
   // (Optional) duration/time omitted to keep UI simple and avoid stutter
   const mutedRef = useRef(false);
   const skipNextPersistRef = useRef(true);
   useEffect(() => { mutedRef.current = muted; }, [muted]);
+
+  // Ensure the player UI anchors to the viewport instead of animated containers.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const existing = document.getElementById("algohub-musicplayer-root");
+    const host = existing ?? document.createElement("div");
+    if (!existing) {
+      host.id = "algohub-musicplayer-root";
+      document.body.appendChild(host);
+    }
+    setPortalContainer(host);
+    return () => {
+      if (!existing && host.parentNode) {
+        host.parentNode.removeChild(host);
+      }
+    };
+  }, []);
 
   // Load stored prefs once on mount to avoid hydration mismatches.
   useEffect(() => {
@@ -325,7 +344,7 @@ export default function MusicPlayer({ playlist }: { playlist?: Track[] }) {
 
   const isOpen = hoverDisc || hoverPanel;
 
-  return (
+  const playerMarkup = (
     <div
       className="fixed bottom-4 right-4 z-50 select-none"
       onMouseLeave={() => { setHoverDisc(false); setHoverPanel(false); }}
@@ -391,6 +410,12 @@ export default function MusicPlayer({ playlist }: { playlist?: Track[] }) {
       </div>
     </div>
   );
+
+  if (!portalContainer) {
+    return null;
+  }
+
+  return createPortal(playerMarkup, portalContainer);
 }
 
 function IconButton({ children, onClick, label, bigger = false }: { children: ReactNode; onClick: () => void; label: string; bigger?: boolean }) {

--- a/types/admin-dashboard.ts
+++ b/types/admin-dashboard.ts
@@ -6,10 +6,27 @@ export type StudentGrowthPoint = {
   totalStudents: number;
 };
 
+export type AchievementGainPoint = {
+  date: string;
+  unlocked: number;
+  totalUnlocked: number;
+};
+
 export type StudentGrowthResponse = {
   data?: StudentGrowthPoint[];
   meta?: {
     totalStudents?: number;
+    windowStart?: string;
+    windowEnd?: string;
+  };
+  generatedAt?: string;
+  error?: string;
+};
+
+export type AchievementGainResponse = {
+  data?: AchievementGainPoint[];
+  meta?: {
+    totalUnlocked?: number;
     windowStart?: string;
     windowEnd?: string;
   };
@@ -25,6 +42,18 @@ export type StudentGrowthCardProps = {
 
 export type StudentGrowthChartProps = {
   data: StudentGrowthPoint[];
+  formatter: Intl.NumberFormat;
+  comparisonLabel: string;
+};
+
+export type AchievementGainCardProps = {
+  data: AchievementGainPoint[] | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export type AchievementGainChartProps = {
+  data: AchievementGainPoint[];
   formatter: Intl.NumberFormat;
   comparisonLabel: string;
 };


### PR DESCRIPTION
This pull request adds a new "Achievements Gained" dashboard metric to the admin panel, displaying daily achievement unlocks across AlgoHub learners. It introduces both backend and frontend logic to fetch, process, and visualize achievement unlock data, and also refactors UI components to use React portals for improved rendering and layering.

**Admin Dashboard: Achievements Gained Feature**

* **Backend API for Achievement Unlocks**  
  Added `app/api/admin/achievements-gained/route.ts`, which provides a new API endpoint returning daily and total achievement unlocks over a rolling window, with robust error handling and efficient aggregation logic.

* **Frontend Data Fetching and State Management**  
  Updated `app/admin/page.tsx` to fetch achievement gain data from the new API, manage loading/error states, and store the results for display. [[1]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R124-R126) [[2]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R178-R223)

* **Dashboard Visualization Components**  
  Implemented `AchievementsGainedCard` and `AchievementsGainedChart` in `app/admin/page.tsx` to render the new metric as a styled card and a responsive SVG line chart, handling empty, loading, and error states gracefully. [[1]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R426-R427) [[2]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R668-R858)

* **Type Definitions**  
  Added new types (`AchievementGainPoint`, `AchievementGainCardProps`, etc.) to `types/admin-dashboard.ts` and imported them as needed for type safety and clarity. [[1]](diffhunk://#diff-6c260e84c0f7a14b6497a657767b2ebf91781c6112262b60de2d53fc81c90094R9-R14) [[2]](diffhunk://#diff-a7c2b21269eaaa6f291a758c44939732a9f1d9fe8e0d71a3a7822b813a196f43R14-R17)

**UI Infrastructure Improvements**

* **React Portal Refactor for Overlay Components**  
  Refactored `IrisTransition` and `MusicPlayer` components to render their overlays/UI into dedicated portal containers attached to `document.body`, ensuring proper layering and avoiding layout issues with animated containers. [[1]](diffhunk://#diff-fb706092457f5bd803347ba3ee9a09490f0bf839b76f59c44305a9a333c980d7R3-R10) [[2]](diffhunk://#diff-fb706092457f5bd803347ba3ee9a09490f0bf839b76f59c44305a9a333c980d7R35-R39) [[3]](diffhunk://#diff-fb706092457f5bd803347ba3ee9a09490f0bf839b76f59c44305a9a333c980d7R107-R119) [[4]](diffhunk://#diff-fb706092457f5bd803347ba3ee9a09490f0bf839b76f59c44305a9a333c980d7L110-R154) [[5]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851R3) [[6]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851R41-R63) [[7]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851L328-R347) [[8]](diffhunk://#diff-3c34356a981a4ee5c932658d60a1506849bcabdc1669631540a468897e807851R413-R418)